### PR TITLE
feat-member-address-update/delete

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>

--- a/src/main/java/com/nhnacademy/bookstore/common/client/SecretDataClient.java
+++ b/src/main/java/com/nhnacademy/bookstore/common/client/SecretDataClient.java
@@ -2,11 +2,13 @@ package com.nhnacademy.bookstore.common.client;
 
 import com.nhnacademy.bookstore.common.dto.response.SecretResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 @FeignClient(name = "secretClient", url = "${keymanager.url}")
+@Profile("!test") // 테스트 환경에서는 비활성화
 public interface SecretDataClient {
     @GetMapping("/appkey/{appKey}/secrets/{keyId}")
     SecretResponseDto getSecret(@PathVariable("appKey") String appkey, @PathVariable("keyId") String keyId,

--- a/src/main/java/com/nhnacademy/bookstore/common/config/MySqlConfig.java
+++ b/src/main/java/com/nhnacademy/bookstore/common/config/MySqlConfig.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
 
 import javax.sql.DataSource;
 import java.time.Duration;

--- a/src/main/java/com/nhnacademy/bookstore/common/error/exception/user/address/AddressNotFoundException.java
+++ b/src/main/java/com/nhnacademy/bookstore/common/error/exception/user/address/AddressNotFoundException.java
@@ -1,0 +1,11 @@
+package com.nhnacademy.bookstore.common.error.exception.user.address;
+
+import com.nhnacademy.bookstore.common.error.enums.RedirectType;
+import com.nhnacademy.bookstore.common.error.exception.base.NotFoundException;
+
+public class AddressNotFoundException extends NotFoundException {
+
+    public AddressNotFoundException(String message, RedirectType redirectType, String url) {
+        super(message, redirectType, url);
+    }
+}

--- a/src/main/java/com/nhnacademy/bookstore/common/error/handler/BaseExceptionHandler.java
+++ b/src/main/java/com/nhnacademy/bookstore/common/error/handler/BaseExceptionHandler.java
@@ -13,10 +13,10 @@ import org.springframework.http.ResponseEntity;
  * @since 1.0
  */
 public interface BaseExceptionHandler {
-    ResponseEntity<ErrorResponseDto<?>> handleBadRequestExceptions(BadRequestException ex);
-    ResponseEntity<ErrorResponseDto<?>> handleUnauthorizedExceptions(UnauthorizedException ex);
-    ResponseEntity<ErrorResponseDto<?>> handleForbiddenExceptions(ForbiddenException ex);
-    ResponseEntity<ErrorResponseDto<?>> handleNotFoundExceptions(NotFoundException ex);
-    ResponseEntity<ErrorResponseDto<?>> handleConflictExceptions(ConflictException ex);
-    ResponseEntity<ErrorResponseDto<?>> handleAllExceptions(Exception ex);
+    ResponseEntity<ErrorResponseDto<Object>> handleBadRequestExceptions(BadRequestException ex);
+    ResponseEntity<ErrorResponseDto<Object>> handleUnauthorizedExceptions(UnauthorizedException ex);
+    ResponseEntity<ErrorResponseDto<Object>> handleForbiddenExceptions(ForbiddenException ex);
+    ResponseEntity<ErrorResponseDto<Object>> handleNotFoundExceptions(NotFoundException ex);
+    ResponseEntity<ErrorResponseDto<Object>> handleConflictExceptions(ConflictException ex);
+    ResponseEntity<ErrorResponseDto<Object>> handleAllExceptions(Exception ex);
 }

--- a/src/main/java/com/nhnacademy/bookstore/coupon/service/impl/MemberCouponServiceImpl.java
+++ b/src/main/java/com/nhnacademy/bookstore/coupon/service/impl/MemberCouponServiceImpl.java
@@ -10,7 +10,6 @@ import com.nhnacademy.bookstore.coupon.service.MemberCouponService;
 import com.nhnacademy.bookstore.user.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/nhnacademy/bookstore/user/member/controller/MemberAddressController.java
+++ b/src/main/java/com/nhnacademy/bookstore/user/member/controller/MemberAddressController.java
@@ -2,8 +2,11 @@ package com.nhnacademy.bookstore.user.member.controller;
 
 import com.nhnacademy.bookstore.common.error.exception.user.address.AddressLimitToTenException;
 import com.nhnacademy.bookstore.common.error.exception.user.member.MemberNotFoundException;
+import com.nhnacademy.bookstore.user.member.dto.request.AddressUpdateRequestDto;
 import com.nhnacademy.bookstore.user.member.dto.request.MemberAddressRequestDto;
-import com.nhnacademy.bookstore.user.member.dto.response.MemberAddressResponseDto;
+import com.nhnacademy.bookstore.user.member.dto.response.address.AddressDeleteResponseDto;
+import com.nhnacademy.bookstore.user.member.dto.response.address.AddressUpdateResponseDto;
+import com.nhnacademy.bookstore.user.member.dto.response.address.MemberAddressResponseDto;
 import com.nhnacademy.bookstore.user.member.service.MemberAddressService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -70,6 +73,28 @@ public class MemberAddressController {
         List<MemberAddressResponseDto> addresses = memberAddressService.getMemberAddresses(Long.parseLong(customerId));
 
         return ResponseEntity.ok(addresses);
+    }
+
+    @DeleteMapping("/addresses/{member-address-id}")
+    public ResponseEntity<AddressDeleteResponseDto> deleteMemberAddress(
+            @RequestHeader("X-Customer-Id") String customerId,
+            @PathVariable(name = "member-address-id") Long memberAddressId) {
+
+
+        AddressDeleteResponseDto response = memberAddressService.deleteMemberAddress(Long.parseLong(customerId), memberAddressId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/addresses/{member-address-id}")
+    public ResponseEntity<AddressUpdateResponseDto> updateMemberAddress(
+            @RequestHeader("X-Customer-Id") String customerId,
+            @PathVariable(name = "member-address-id") Long memberAddressId,
+            @RequestBody @Valid AddressUpdateRequestDto requestDto) {
+
+        AddressUpdateResponseDto response = memberAddressService.updateMemberAddress(Long.parseLong(customerId), memberAddressId, requestDto);
+
+        return ResponseEntity.ok(response);
     }
 
 

--- a/src/main/java/com/nhnacademy/bookstore/user/member/dto/request/AddressUpdateRequestDto.java
+++ b/src/main/java/com/nhnacademy/bookstore/user/member/dto/request/AddressUpdateRequestDto.java
@@ -1,15 +1,12 @@
 package com.nhnacademy.bookstore.user.member.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
-
 import java.io.Serializable;
 
-
-public record MemberAddressRequestDto(
+public record AddressUpdateRequestDto(
 
         @NotBlank(message = "우편번호는 필수 입력사항입니다.")
         @Pattern(regexp = "\\d{5}", message = "우편번호는 5자리 숫자여야 합니다.")
@@ -25,10 +22,8 @@ public record MemberAddressRequestDto(
         @Size(max = 50, message = "주소 별칭은 최대 50자까지 입력 가능합니다.")
         String addressAlias,
 
-        @NotNull(message = "기본 주소 설정 여부는 필수 입력사항입니다.")
-        boolean defaultAddress,
-
         @NotBlank(message = "수신인 정보는 필수 입력사항입니다.")
         @Size(max = 20, message = "수신인 이름은 최대 20자까지 입력 가능합니다.")
         String receiver
+
 ) implements Serializable {}

--- a/src/main/java/com/nhnacademy/bookstore/user/member/dto/response/address/AddressDeleteResponseDto.java
+++ b/src/main/java/com/nhnacademy/bookstore/user/member/dto/response/address/AddressDeleteResponseDto.java
@@ -1,0 +1,8 @@
+package com.nhnacademy.bookstore.user.member.dto.response.address;
+
+public record AddressDeleteResponseDto(
+        Long memberAddressId,
+        String message
+
+) {
+}

--- a/src/main/java/com/nhnacademy/bookstore/user/member/dto/response/address/AddressUpdateResponseDto.java
+++ b/src/main/java/com/nhnacademy/bookstore/user/member/dto/response/address/AddressUpdateResponseDto.java
@@ -1,0 +1,7 @@
+package com.nhnacademy.bookstore.user.member.dto.response.address;
+
+public record AddressUpdateResponseDto(
+        long memberAddressId,
+        String message
+) {
+}

--- a/src/main/java/com/nhnacademy/bookstore/user/member/dto/response/address/MemberAddressResponseDto.java
+++ b/src/main/java/com/nhnacademy/bookstore/user/member/dto/response/address/MemberAddressResponseDto.java
@@ -1,4 +1,4 @@
-package com.nhnacademy.bookstore.user.member.dto.response;
+package com.nhnacademy.bookstore.user.member.dto.response.address;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/com/nhnacademy/bookstore/user/member/entity/MemberAddress.java
+++ b/src/main/java/com/nhnacademy/bookstore/user/member/entity/MemberAddress.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.bookstore.user.member.entity;
 
+import com.nhnacademy.bookstore.user.member.dto.request.AddressUpdateRequestDto;
 import com.nhnacademy.bookstore.user.member.dto.request.MemberAddressRequestDto;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -39,11 +40,13 @@ public class MemberAddress {
     private String addressAlias;
 
     @Setter
-    @Column(name="is_default_address", columnDefinition = "TINYINT(1)")
-
+    @Column(name="is_default_address")
     private boolean defaultAddress;
 
     private String receiver;
+
+    @Setter
+    private boolean available;
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "customer_id", nullable = false)
@@ -57,12 +60,19 @@ public class MemberAddress {
      * @param member     주소를 소유한 회원 객체
      */
     public void toEntity(MemberAddressRequestDto requestDto, Member member){
-        this.postalCode = requestDto.getPostalCode();
-        this.roadAddress = requestDto.getRoadAddress();
-        this.detailAddress = requestDto.getDetailAddress();
-        this.addressAlias = requestDto.getAddressAlias();
-        this.defaultAddress = requestDto.isDefaultAddress();
-        this.receiver = requestDto.getReceiver();
+        this.postalCode = requestDto.postalCode();
+        this.roadAddress = requestDto.roadAddress();
+        this.detailAddress = requestDto.detailAddress();
+        this.addressAlias = requestDto.addressAlias();
+        this.defaultAddress = requestDto.defaultAddress();
+        this.receiver = requestDto.receiver();
         this.member = member;
+    }
+    public void updateAddress(AddressUpdateRequestDto requestDto){
+        this.postalCode = requestDto.postalCode();
+        this.roadAddress = requestDto.roadAddress();
+        this.detailAddress = requestDto.detailAddress();
+        this.addressAlias = requestDto.addressAlias();
+        this.receiver = requestDto.receiver();
     }
 }

--- a/src/main/java/com/nhnacademy/bookstore/user/member/entity/MemberAddress.java
+++ b/src/main/java/com/nhnacademy/bookstore/user/member/entity/MemberAddress.java
@@ -67,6 +67,7 @@ public class MemberAddress {
         this.defaultAddress = requestDto.defaultAddress();
         this.receiver = requestDto.receiver();
         this.member = member;
+        this.available = true;
     }
     public void updateAddress(AddressUpdateRequestDto requestDto){
         this.postalCode = requestDto.postalCode();

--- a/src/main/java/com/nhnacademy/bookstore/user/member/repository/MemberAddressQuerydslRepository.java
+++ b/src/main/java/com/nhnacademy/bookstore/user/member/repository/MemberAddressQuerydslRepository.java
@@ -1,6 +1,6 @@
 package com.nhnacademy.bookstore.user.member.repository;
 
-import com.nhnacademy.bookstore.user.member.dto.response.MemberAddressResponseDto;
+import com.nhnacademy.bookstore.user.member.dto.response.address.MemberAddressResponseDto;
 
 import java.util.List;
 

--- a/src/main/java/com/nhnacademy/bookstore/user/member/repository/MemberAddressRepository.java
+++ b/src/main/java/com/nhnacademy/bookstore/user/member/repository/MemberAddressRepository.java
@@ -3,10 +3,14 @@ package com.nhnacademy.bookstore.user.member.repository;
 import com.nhnacademy.bookstore.user.member.entity.MemberAddress;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 
 public interface MemberAddressRepository  extends JpaRepository<MemberAddress, Long>, MemberAddressQuerydslRepository {
 
-    int countByMemberId(Long memberId);
+    int countByMemberIdAndAvailableTrue(Long memberId);
     MemberAddress findByMemberIdAndDefaultAddressTrue(Long memberId);
+    Optional<MemberAddress> findByMemberIdAndIdAndAvailableTrue(long memberId, long addressId);
+
 
 }

--- a/src/main/java/com/nhnacademy/bookstore/user/member/repository/impl/MemberAddressQuerydslRepositoryImpl.java
+++ b/src/main/java/com/nhnacademy/bookstore/user/member/repository/impl/MemberAddressQuerydslRepositoryImpl.java
@@ -30,7 +30,10 @@ public class MemberAddressQuerydslRepositoryImpl implements MemberAddressQueryds
                         memberAddress.receiver
                 ))
                 .from(memberAddress)
-                .where(memberAddress.member.id.eq(memberId))
+                .where(
+                        memberAddress.member.id.eq(memberId) // memberId 조건
+                                .and(memberAddress.available.isTrue()) // available 필드가 true인 조건 추가
+                )
                 .orderBy(
                         memberAddress.defaultAddress.desc(), // isDefaultAddress가 true인 항목 먼저
                         memberAddress.id.desc()              // 가장 마지막에 등록된 순서대로

--- a/src/main/java/com/nhnacademy/bookstore/user/member/repository/impl/MemberAddressQuerydslRepositoryImpl.java
+++ b/src/main/java/com/nhnacademy/bookstore/user/member/repository/impl/MemberAddressQuerydslRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.nhnacademy.bookstore.user.member.repository.impl;
 
-import com.nhnacademy.bookstore.user.member.dto.response.MemberAddressResponseDto;
+import com.nhnacademy.bookstore.user.member.dto.response.address.MemberAddressResponseDto;
 import com.nhnacademy.bookstore.user.member.repository.MemberAddressQuerydslRepository;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;

--- a/src/main/java/com/nhnacademy/bookstore/user/member/service/MemberAddressService.java
+++ b/src/main/java/com/nhnacademy/bookstore/user/member/service/MemberAddressService.java
@@ -1,7 +1,10 @@
 package com.nhnacademy.bookstore.user.member.service;
 
+import com.nhnacademy.bookstore.user.member.dto.request.AddressUpdateRequestDto;
 import com.nhnacademy.bookstore.user.member.dto.request.MemberAddressRequestDto;
-import com.nhnacademy.bookstore.user.member.dto.response.MemberAddressResponseDto;
+import com.nhnacademy.bookstore.user.member.dto.response.address.AddressDeleteResponseDto;
+import com.nhnacademy.bookstore.user.member.dto.response.address.AddressUpdateResponseDto;
+import com.nhnacademy.bookstore.user.member.dto.response.address.MemberAddressResponseDto;
 
 import java.util.List;
 
@@ -15,4 +18,6 @@ import java.util.List;
 public interface MemberAddressService {
     List<MemberAddressResponseDto> addMemberAddress(long memberId, MemberAddressRequestDto memberAddressRequestDto);
     List<MemberAddressResponseDto> getMemberAddresses(long memberId);
+    AddressDeleteResponseDto deleteMemberAddress(long customerId, long addressId);
+    AddressUpdateResponseDto updateMemberAddress(long customerId, long addressId, AddressUpdateRequestDto requestDto);
 }

--- a/src/main/java/com/nhnacademy/bookstore/user/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/nhnacademy/bookstore/user/member/service/impl/MemberServiceImpl.java
@@ -43,7 +43,7 @@ public class MemberServiceImpl implements MemberService {
     static final String MEMBER_SIGNUP_URL = "/signup";
     static final String MEMBER_EDIT_PROFILE_URL = "/mypage/edit-profile";
     static final String MEMBER_WITHDRAW_URL = "/mypage/withdraw";
-    private final static int INITIAL_PAGE_SIZE = 10;
+    private static final int INITIAL_PAGE_SIZE = 10;
 
     private final MemberRepository memberRepository;
     private final MemberStatusRepository statusRepository;

--- a/src/test/java/com/nhnacademy/bookstore/user/member/MemberControllerTest.java
+++ b/src/test/java/com/nhnacademy/bookstore/user/member/MemberControllerTest.java
@@ -224,7 +224,7 @@ import static org.mockito.Mockito.when;
       when(memberService.getPointsOfMember(customerId)).thenReturn(mockPoint);
       ResponseEntity<MemberPointResponse> actualResponse = memberController.getPoint(customerId);
 
-      assertEquals(actualResponse.getStatusCode(), HttpStatus.OK);
+      assertEquals(HttpStatus.OK, actualResponse.getStatusCode());
       assertEquals(mockPoint, actualResponse.getBody());
    }
 

--- a/src/test/java/com/nhnacademy/bookstore/user/member/MemberQuerydslRepositoryImplTest.java
+++ b/src/test/java/com/nhnacademy/bookstore/user/member/MemberQuerydslRepositoryImplTest.java
@@ -1,90 +1,129 @@
-//package com.nhnacademy.bookstore.user.member;
-//
-//import com.nhnacademy.bookstore.common.error.exception.user.member.status.MemberNothingToUpdateException;
-//import com.nhnacademy.bookstore.user.enums.Gender;
-//import com.nhnacademy.bookstore.user.member.dto.request.MemberUpdateRequesteDto;
-//import com.nhnacademy.bookstore.user.member.dto.response.MemberUpdateResponseDto;
-//import com.nhnacademy.bookstore.user.member.repository.MemberQuerydslRepository;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.beans.factory.annotation.Qualifier;
-//import org.springframework.boot.test.context.SpringBootTest;
-//import org.springframework.test.context.ActiveProfiles;
-//import org.springframework.transaction.annotation.Transactional;
-//
-//import java.time.LocalDate;
-//
-//import static org.junit.jupiter.api.Assertions.*;
-//
-//@ActiveProfiles("dev")
-//@SpringBootTest
-//class MemberQuerydslRepositoryImplTest {
-//
-//    @Autowired
-//    @Qualifier("memberQuerydslRepositoryImpl") // 정확한 빈 이름으로 변경
-//    private MemberQuerydslRepository memberQuerydslRepository;
-//
-//    private long testMemberId;
-//
-//    @BeforeEach
-//    @Transactional
-//    void setUp() {
-//        // 테스트 데이터를 세팅하는 부분입니다.
-//        // 실제로는 데이터베이스에 기본 데이터를 삽입하거나 Mock을 사용할 수 있습니다.
-//        testMemberId = 1L; // 예시로 멤버 ID를 1로 설정
-//    }
-//
-//    @Test
-//    @Transactional
-//    void testUpdateMemberDetails_Success() {
-//        // Given
-//        MemberUpdateRequesteDto requestDto = new MemberUpdateRequesteDto(
-//                "010-1234-5678", "john.doe@example.com", "John");
-//
-//        // When
-//        MemberUpdateResponseDto responseDto = memberQuerydslRepository.updateMemberDetails(requestDto, testMemberId);
-//
-//        // Then
-//        assertNotNull(responseDto);
-//        assertEquals("010-1234-5678", responseDto.phone());
-//        assertEquals("john.doe@example.com", responseDto.email());
-//        assertEquals("John", responseDto.nickName());
-//    }
-//
-//
-//
-//    @Test
-//    void testUpdateMemberDetails_NoFieldsToUpdate() {
-//        // Given: 업데이트할 데이터가 없는 요청
-//        MemberUpdateRequesteDto requestDto = new MemberUpdateRequesteDto(null, null, null);
-//
-//        // When & Then: 예외 발생 검증
-//        MemberNothingToUpdateException exception = assertThrows(
-//                MemberNothingToUpdateException.class,
-//                () -> memberQuerydslRepository.updateMemberDetails(requestDto, testMemberId)
-//        );
-//
-//        assertTrue(exception.getMessage().contains("업데이트할 데이터가 없습니다."));
-//    }
-//    @Test
-//    @Transactional
-//    void testGetMemberInfo_Success() {
-//        // Given
-//        MemberUpdateResponseDto expectedResponse = new MemberUpdateResponseDto(
-//                "John Doe", Gender.M, LocalDate.of(1990, 1, 1),
-//                "010-1234-5678", "johndoe@example.com", "USER1"
-//        );
-//
-//        MemberUpdateResponseDto responseDto = memberQuerydslRepository.getMemberInfo(testMemberId);
-//
-//        // Then
-//        assertNotNull(responseDto);
-//        assertEquals(expectedResponse.name(), responseDto.name());
-//        assertEquals(expectedResponse.gender(), responseDto.gender());
-//        assertEquals(expectedResponse.birthday(), responseDto.birthday());
-//        assertEquals(expectedResponse.phone(), responseDto.phone());
-//        assertEquals(expectedResponse.email(), responseDto.email());
-//        assertEquals(expectedResponse.nickName(), responseDto.nickName());
-//    }
-//}
+package com.nhnacademy.bookstore.user.member;
+
+
+import com.nhnacademy.bookstore.common.config.QuerydslConfig;
+import com.nhnacademy.bookstore.common.error.exception.user.member.status.MemberNothingToUpdateException;
+import com.nhnacademy.bookstore.user.enums.Gender;
+import com.nhnacademy.bookstore.user.member.dto.request.MemberUpdateRequesteDto;
+import com.nhnacademy.bookstore.user.member.dto.response.MemberUpdateResponseDto;
+import com.nhnacademy.bookstore.user.member.entity.Member;
+import com.nhnacademy.bookstore.user.member.repository.impl.MemberQuerydslRepositoryImpl;
+import com.nhnacademy.bookstore.user.memberstatus.entity.MemberStatus;
+import com.nhnacademy.bookstore.user.tier.entity.MemberTier;
+import com.nhnacademy.bookstore.user.tier.enums.Tier;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+@DataJpaTest
+@Import(QuerydslConfig.class)
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class MemberQuerydslRepositoryImplTest {
+
+    @Autowired
+    private MemberQuerydslRepositoryImpl memberQuerydslRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @BeforeEach
+    void setUp() {
+
+        MemberStatus status = new MemberStatus(1L, "가입");
+        entityManager.merge(status);
+
+        MemberTier tier = new MemberTier(1L, Tier.NORMAL, true, 1, 1, 1);
+        entityManager.merge(tier);
+
+        // 2. 강제로 flush() 및 clear() 호출
+        entityManager.flush();
+        entityManager.clear();
+
+        // 3. 저장한 엔티티를 다시 조회
+        MemberStatus persistedStatus = entityManager.find(MemberStatus.class, 1L);
+        MemberTier persistedTier = entityManager.find(MemberTier.class, 1L);
+
+        // Member 엔티티를 저장
+        Member member = new Member(
+                "testLoginId", "Test Member", "nick", Gender.M, LocalDate.now(),
+                10, LocalDate.now(), null, false, 0, 0, null,
+                null, persistedStatus, persistedTier, null
+        );
+        member.initializeCustomerFields("이한빈", "010-2222-1223", "dlgksqls@naver.com");
+        entityManager.persist(member);
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Test
+    @Transactional
+    void testGetMemberInfo() {
+        // given
+        long memberId = 1L;
+
+        // when
+        MemberUpdateResponseDto result = memberQuerydslRepository.getMemberInfo(memberId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.name()).isEqualTo("이한빈");
+        assertThat(result.email()).isEqualTo("dlgksqls@naver.com");
+        assertThat(result.phone()).isEqualTo("010-2222-1223");
+    }
+    @Test
+    void testUpdateMemberDetails_success() {
+        // given
+        long memberId = 1L;
+        MemberUpdateRequesteDto updateRequest = new MemberUpdateRequesteDto("010-3333-4444", "newemail@example.com", "newNick");
+
+        // when
+        MemberUpdateResponseDto result = memberQuerydslRepository.updateMemberDetails(updateRequest, memberId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.phone()).isEqualTo("010-3333-4444");
+        assertThat(result.email()).isEqualTo("newemail@example.com");
+        assertThat(result.nickName()).isEqualTo("newNick");
+    }
+
+    @Test
+    void testUpdateMemberDetails_noUpdateData() {
+        // given
+        long memberId = 1L;
+        MemberUpdateRequesteDto updateRequest = new MemberUpdateRequesteDto(null, null, null);
+
+        // when / then
+        assertThatThrownBy(() -> memberQuerydslRepository.updateMemberDetails(updateRequest, memberId))
+                .isInstanceOf(MemberNothingToUpdateException.class)
+                .hasMessageContaining("업데이트할 데이터가 없습니다.");
+    }
+
+    @Test
+    void testUpdateMemberDetails_partialUpdate() {
+        // given
+        long memberId = 1L;
+        MemberUpdateRequesteDto updateRequest = new MemberUpdateRequesteDto(null, "updatedemail@example.com", null);
+
+        // when
+        MemberUpdateResponseDto result = memberQuerydslRepository.updateMemberDetails(updateRequest, memberId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.email()).isEqualTo("updatedemail@example.com");
+        assertThat(result.phone()).isEqualTo("010-2222-1223"); // 기존 값 유지
+        assertThat(result.nickName()).isEqualTo("nick"); // 기존 값 유지
+    }
+}

--- a/src/test/java/com/nhnacademy/bookstore/user/member/MemberServiceImplTest.java
+++ b/src/test/java/com/nhnacademy/bookstore/user/member/MemberServiceImplTest.java
@@ -7,7 +7,6 @@ import com.nhnacademy.bookstore.common.error.exception.user.member.MemberPasswor
 import com.nhnacademy.bookstore.common.error.exception.user.member.status.MemberNothingToUpdateException;
 import com.nhnacademy.bookstore.common.error.exception.user.member.status.MemberStatusNotFoundException;
 import com.nhnacademy.bookstore.common.error.exception.user.member.tier.MemberTierNotFoundException;
-import com.nhnacademy.bookstore.coupon.service.MemberCouponService;
 import com.nhnacademy.bookstore.coupon.service.impl.MemberCouponServiceImpl;
 import com.nhnacademy.bookstore.user.enums.Gender;
 import com.nhnacademy.bookstore.user.member.dto.request.MemberCreateRequestDto;
@@ -543,7 +542,6 @@ class MemberServiceImplTest {
     @Test
     @DisplayName("없는 회원의 포인트 조회")
     void testGetPointsOfMember_NotFound() {
-        MemberPointResponse mockPoint = new MemberPointResponse(100);
         when(memberRepository.findPointById(1L)).thenThrow(MemberNotFoundException.class);
         assertThrows(MemberNotFoundException.class, () -> memberService.getPointsOfMember(1L));
     }

--- a/src/test/java/com/nhnacademy/bookstore/user/member/address/MemberAddressControllerTest.java
+++ b/src/test/java/com/nhnacademy/bookstore/user/member/address/MemberAddressControllerTest.java
@@ -2,9 +2,13 @@ package com.nhnacademy.bookstore.user.member.address;
 
 import com.nhnacademy.bookstore.common.error.enums.RedirectType;
 import com.nhnacademy.bookstore.common.error.exception.user.address.AddressLimitToTenException;
+import com.nhnacademy.bookstore.common.error.exception.user.address.AddressNotFoundException;
 import com.nhnacademy.bookstore.user.member.controller.MemberAddressController;
+import com.nhnacademy.bookstore.user.member.dto.request.AddressUpdateRequestDto;
 import com.nhnacademy.bookstore.user.member.dto.request.MemberAddressRequestDto;
-import com.nhnacademy.bookstore.user.member.dto.response.MemberAddressResponseDto;
+import com.nhnacademy.bookstore.user.member.dto.response.address.AddressDeleteResponseDto;
+import com.nhnacademy.bookstore.user.member.dto.response.address.AddressUpdateResponseDto;
+import com.nhnacademy.bookstore.user.member.dto.response.address.MemberAddressResponseDto;
 import com.nhnacademy.bookstore.user.member.service.MemberAddressService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -92,6 +96,89 @@ class MemberAddressControllerTest {
                 .when(memberAddressService).addMemberAddress(memberId, requestDto);
 
         // when & then
-        assertThrows(AddressLimitToTenException.class, () -> memberAddressController.addMemberAddress(String.valueOf(memberId), requestDto));
+        assertThrows(AddressLimitToTenException.class, () -> invokeAddMemberAddress(memberId, requestDto));
     }
+    private void invokeAddMemberAddress(long memberId, MemberAddressRequestDto requestDto) {
+        memberAddressController.addMemberAddress(String.valueOf(memberId), requestDto);
+    }
+    /**
+     * 테스트: 주소 삭제 성공 시 응답 검증
+     * 예상 결과: 200 OK 응답 코드와 함께 삭제된 주소 정보 반환
+     */
+    @Test
+    void testDeleteMemberAddress_Success() {
+        // given
+        String customerId = "1";
+        Long memberAddressId = 10L;
+        AddressDeleteResponseDto responseDto = new AddressDeleteResponseDto(memberAddressId, "주소가 성공적으로 삭제되었습니다.");
+
+        when(memberAddressService.deleteMemberAddress(Long.parseLong(customerId), memberAddressId)).thenReturn(responseDto);
+
+        // when
+        ResponseEntity<AddressDeleteResponseDto> response = memberAddressController.deleteMemberAddress(customerId, memberAddressId);
+
+        // then
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(memberAddressId, Objects.requireNonNull(response.getBody()).memberAddressId());
+        assertEquals("주소가 성공적으로 삭제되었습니다.", response.getBody().message());
+    }
+
+    /**
+     * 테스트: 주소 삭제 실패 시 예외 발생 확인
+     * 예상 결과: AddressNotFoundException 발생
+     */
+    @Test
+    void testDeleteMemberAddress_AddressNotFoundException() {
+        // given
+        String customerId = "1";
+        long memberAddressId = 10L;
+
+        doThrow(new AddressNotFoundException("주소를 찾을 수 없습니다.", RedirectType.REDIRECT, "mypage"))
+                .when(memberAddressService).deleteMemberAddress(Long.parseLong(customerId), memberAddressId);
+
+        // when & then
+        assertThrows(AddressNotFoundException.class, () -> memberAddressController.deleteMemberAddress(customerId, memberAddressId));
+    }
+
+    /**
+     * 테스트: 주소 업데이트 성공 시 응답 검증
+     * 예상 결과: 200 OK 응답 코드와 함께 업데이트된 주소 정보 반환
+     */
+    @Test
+    void testUpdateMemberAddress_Success() {
+        // given
+        String customerId = "1";
+        Long memberAddressId = 10L;
+        AddressUpdateRequestDto requestDto = new AddressUpdateRequestDto("12345", "도로명 주소", "상세 주소", "별칭",  "수신인");
+        AddressUpdateResponseDto responseDto = new AddressUpdateResponseDto(memberAddressId, "주소가 성공적으로 업데이트되었습니다.");
+
+        when(memberAddressService.updateMemberAddress(Long.parseLong(customerId), memberAddressId, requestDto)).thenReturn(responseDto);
+
+        // when
+        ResponseEntity<AddressUpdateResponseDto> response = memberAddressController.updateMemberAddress(customerId, memberAddressId, requestDto);
+
+        // then
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(memberAddressId, Objects.requireNonNull(response.getBody()).memberAddressId());
+        assertEquals("주소가 성공적으로 업데이트되었습니다.", response.getBody().message());
+    }
+
+    /**
+     * 테스트: 주소 업데이트 실패 시 예외 발생 확인
+     * 예상 결과: AddressNotFoundException 발생
+     */
+    @Test
+    void testUpdateMemberAddress_AddressNotFoundException() {
+        // given
+        String customerId = "1";
+        long memberAddressId = 10L;
+        AddressUpdateRequestDto requestDto = new AddressUpdateRequestDto("12345", "도로명 주소", "상세 주소", "별칭", "수신인");
+
+        doThrow(new AddressNotFoundException("주소를 찾을 수 없습니다.", RedirectType.REDIRECT, "mypage"))
+                .when(memberAddressService).updateMemberAddress(Long.parseLong(customerId), memberAddressId, requestDto);
+
+        // when & then
+        assertThrows(AddressNotFoundException.class, () -> memberAddressController.updateMemberAddress(customerId, memberAddressId, requestDto));
+    }
+
 }

--- a/src/test/java/com/nhnacademy/bookstore/user/member/address/MemberAddressQuerydslRepositoryImplTest.java
+++ b/src/test/java/com/nhnacademy/bookstore/user/member/address/MemberAddressQuerydslRepositoryImplTest.java
@@ -1,66 +1,121 @@
-//package com.nhnacademy.bookstore.user.member.address;
-//
-//
-//import com.nhnacademy.bookstore.user.member.dto.response.MemberAddressResponseDto;
-//import com.nhnacademy.bookstore.user.member.repository.MemberAddressQuerydslRepository;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.beans.factory.annotation.Qualifier;
-//import org.springframework.boot.test.context.SpringBootTest;
-//import org.springframework.test.context.ActiveProfiles;
-//import org.springframework.transaction.annotation.Transactional;
-//
-//import java.util.List;
-//
-//import static org.junit.jupiter.api.Assertions.*;
-//
-//@ActiveProfiles("dev")
-//@SpringBootTest
-// class MemberAddressQuerydslRepositoryImplTest {
-//
-//    @Autowired
-//    @Qualifier("memberAddressQuerydslRepositoryImpl") // 정확한 빈 이름으로 변경
-//    private MemberAddressQuerydslRepository memberAddressQuerydslRepository;
-//
-//    private long testMemberId;
-//
-//    @BeforeEach
-//    @Transactional
-//    void setUp() {
-//        // 테스트 데이터 세팅
-//        testMemberId = 84L; // 테스트 멤버 ID를 설정
-//        // 데이터베이스에 샘플 주소 데이터를 추가하는 작업을 수행
-//        // 필요한 경우 JPA Repository 또는 다른 데이터 삽입 방법 사용
-//    }
-//
-//    @Test
-//    @Transactional
-//    void testFindAddressesByMemberId_Success() {
-//        // Given
-//        // 사전에 설정된 testMemberId와 연결된 데이터가 있다고 가정
-//
-//        // When
-//        List<MemberAddressResponseDto> addressList = memberAddressQuerydslRepository.findAddressesByMemberId(testMemberId);
-//
-//        // Then
-//        assertNotNull(addressList);
-//        assertFalse(addressList.isEmpty(), "멤버의 주소가 조회되어야 합니다.");
-//    }
-//
-//    @Test
-//    @Transactional
-//    void testFindAddressesByMemberId_NoAddresses() {
-//        // Given
-//        long invalidMemberId = -1L; // 존재하지 않는 멤버 ID
-//
-//        // When
-//        List<MemberAddressResponseDto> addressList = memberAddressQuerydslRepository.findAddressesByMemberId(invalidMemberId);
-//
-//        // Then
-//        assertNotNull(addressList, "결과 리스트는 null이 아니어야 합니다.");
-//        assertEquals(0, addressList.size(), "주소가 없으므로 결과 리스트 크기는 0이어야 합니다.");
-//    }
-//
-//
-//}
+package com.nhnacademy.bookstore.user.member.address;
+
+
+import com.nhnacademy.bookstore.common.config.MySqlConfig;
+import com.nhnacademy.bookstore.common.config.QuerydslConfig;
+import com.nhnacademy.bookstore.user.enums.Gender;
+import com.nhnacademy.bookstore.user.member.dto.response.address.MemberAddressResponseDto;
+import com.nhnacademy.bookstore.user.member.entity.Member;
+import com.nhnacademy.bookstore.user.member.entity.MemberAddress;
+import com.nhnacademy.bookstore.user.member.repository.impl.MemberAddressQuerydslRepositoryImpl;
+import com.nhnacademy.bookstore.user.memberstatus.entity.MemberStatus;
+import com.nhnacademy.bookstore.user.tier.entity.MemberTier;
+import com.nhnacademy.bookstore.user.tier.enums.Tier;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(QuerydslConfig.class) // QueryDSL 및 설정 클래스 포함
+@ActiveProfiles("test") // test 프로파일 활성화
+@ImportAutoConfiguration(exclude = MySqlConfig.class) // MySqlConfig 비활성화
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class MemberAddressQuerydslRepositoryImplTest {
+
+    @Autowired
+    private MemberAddressQuerydslRepositoryImpl memberAddressQuerydslRepository;
+
+
+
+    @Autowired
+    private EntityManager entityManager;
+
+
+    @BeforeEach
+    void setUp() {
+
+
+        MemberStatus status = new MemberStatus(1L, "가입");
+        entityManager.merge(status);
+
+        MemberTier tier = new MemberTier(1L, Tier.NORMAL, true, 1, 1, 1);
+        entityManager.merge(tier);
+
+        // 2. 강제로 flush() 및 clear() 호출
+        entityManager.flush();
+        entityManager.clear();
+
+        // 3. 저장한 엔티티를 다시 조회
+        MemberStatus persistedStatus = entityManager.find(MemberStatus.class, 1L);
+        MemberTier persistedTier = entityManager.find(MemberTier.class, 1L);
+
+        // 테스트 데이터 초기화
+        Member member = new Member("testLoginId", "Test Member", "nick", Gender.M, LocalDate.now(), 10, LocalDate.now(), null, false, 0, 0, null,
+        null, persistedStatus, persistedTier, null);
+        member.initializeCustomerFields("이한빈", "010-2222-1223", "dlgksqls@naver.com");
+        entityManager.merge(member);
+
+
+        // 2. 강제로 flush() 및 clear() 호출
+        entityManager.flush();
+        entityManager.clear();
+
+        // 3. 저장한 엔티티를 다시 조회
+        Member persistMember = entityManager.find(Member.class, 1L);
+        MemberAddress address1 = new MemberAddress(
+                null,
+                "12345",
+                "Road Address 1",
+                "Detail Address 1",
+                "Home",
+                true,
+                "Receiver 1"
+                , true,
+                persistMember
+        );
+        entityManager.persist(address1);
+
+        MemberAddress address2 = new MemberAddress(
+                null,
+                "67890",
+                "Road Address 2",
+                "Detail Address 2",
+                "Work",
+                false,
+                "Receiver 2",
+                true,
+                persistMember
+        );
+        entityManager.persist(address2);
+
+        entityManager.flush(); // 데이터 반영
+        entityManager.clear(); // 영속성 컨텍스트 초기화
+    }
+
+    @Test
+    @Transactional
+    void testFindAddressesByMemberId() {
+        // given
+        long memberId = 1L;
+
+        // when
+        List<MemberAddressResponseDto> result = memberAddressQuerydslRepository.findAddressesByMemberId(memberId);
+
+        // then
+        assertThat(result).hasSize(2); // 주소 2개가 반환되어야 함
+        assertThat(result.get(0).isDefaultAddress()).isTrue(); // 첫 번째 주소는 defaultAddress
+        assertThat(result.get(1).addressAlias()).isEqualTo("Work"); // 두 번째 주소의 별칭 확인
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,17 @@
+# H2 ?????? ??
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+server.port=8080
+
+# Hibernate ?? ?? (??? ????? ddl-auto? update ?? create-drop)
+spring.jpa.hibernate.ddl-auto=update
+
+# SQL ?? ?? (????)
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console


### PR DESCRIPTION
회원 배송지 수정, 삭제 로직입니다. 

기존 querydsl 테스트 코드 주석 처리 되어 있는거
 
Test profile 넣어서 h2 환경에서 테스트 진행하는 식으로 변경되었습니다. 
mysql의 데이터 베이스 변동에 영향없게 처리 했습니다.