### PR TITLE
주문상세 내림차순 정렬

### DIFF
--- a/src/main/java/com/nhnacademy/bookstore/bookset/publisher/controller/PublisherController.java
+++ b/src/main/java/com/nhnacademy/bookstore/bookset/publisher/controller/PublisherController.java
@@ -59,7 +59,7 @@ public class PublisherController {
      */
     @Operation(summary = "전체 출판사 조회", description = "등록된 모든 출판사를 조회합니다.")
     @GetMapping("/publishers")
-    public ResponseEntity<Page<PublisherResponseDto>> getAllPublishers(@PageableDefault(size = 10, sort = "id", direction = Sort.Direction.ASC) Pageable pageable) {
+    public ResponseEntity<Page<PublisherResponseDto>> getAllPublishers(Pageable pageable) {
         Page<PublisherResponseDto> publishers = publisherService.getAllPublishers(pageable);
         return ResponseEntity.status(HttpStatus.OK).body(publishers);
     }

--- a/src/main/java/com/nhnacademy/bookstore/bookset/publisher/repository/PublisherRepositoryImpl.java
+++ b/src/main/java/com/nhnacademy/bookstore/bookset/publisher/repository/PublisherRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.nhnacademy.bookstore.bookset.publisher.repository;
 import com.nhnacademy.bookstore.bookset.publisher.dto.response.PublisherResponseDto;
 import com.nhnacademy.bookstore.bookset.publisher.entity.Publisher;
 import com.nhnacademy.bookstore.bookset.publisher.entity.QPublisher;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQuery;
 import jakarta.persistence.EntityManager;
@@ -31,22 +32,23 @@ public class PublisherRepositoryImpl extends QuerydslRepositorySupport implement
     public Page<PublisherResponseDto> findAllBy(Pageable pageable) {
         // PublisherResponseDto 리스트를 조회하는 쿼리
         JPAQuery<PublisherResponseDto> query = new JPAQuery<>(entityManager);
-        List<PublisherResponseDto> results = query
-                .select(Projections.constructor(PublisherResponseDto.class,
+
+        // 정렬 조건 추가
+        query.select(Projections.constructor(PublisherResponseDto.class,
                         publisher.publisherId,
                         publisher.name
                 ))
                 .from(publisher)
+                .orderBy(publisher.publisherId.asc())  // 정렬 조건 추가
                 .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+                .limit(pageable.getPageSize());
+
+        List<PublisherResponseDto> results = query.fetch();
 
         // 전체 개수를 조회하는 쿼리
-        JPAQuery<Long> countQuery = new JPAQuery<>(entityManager);
-        long total = countQuery
-                .from(publisher)
-                .fetchCount();
+        long total = query.fetchCount();
 
         return new PageImpl<>(results, pageable, total);
     }
+
 }

--- a/src/main/java/com/nhnacademy/bookstore/orderset/order_detail/controller/OrderDetailController.java
+++ b/src/main/java/com/nhnacademy/bookstore/orderset/order_detail/controller/OrderDetailController.java
@@ -28,8 +28,7 @@ public class OrderDetailController {
 
     @Operation(summary = "고객ID로 주문 상세 조회", description = "고객에 관련된 주문상세를 조회합니다.")
     @GetMapping("/customer")
-    public ResponseEntity<Page<OrderDetailResponseDto>> getOrderDetailsByCustomerId(
-            @PageableDefault(size = 10, sort = "orderDetailId", direction = Sort.Direction.ASC) Pageable pageable,
+    public ResponseEntity<Page<OrderDetailResponseDto>> getOrderDetailsByCustomerId(Pageable pageable,
             @RequestHeader("X-Customer-Id") String customerId) {
         Page<OrderDetailResponseDto> orderDetails = orderDetailService.getOrderDetailByCustomerId(pageable, Long.valueOf(customerId));
         return ResponseEntity.ok(orderDetails);

--- a/src/main/java/com/nhnacademy/bookstore/orderset/order_detail/repository/OrderDetailRepository.java
+++ b/src/main/java/com/nhnacademy/bookstore/orderset/order_detail/repository/OrderDetailRepository.java
@@ -1,17 +1,14 @@
 package com.nhnacademy.bookstore.orderset.order_detail.repository;
 
-import com.nhnacademy.bookstore.orderset.order_detail.dto.response.OrderDetailResponseDto;
 import com.nhnacademy.bookstore.orderset.order_detail.entity.OrderDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface OrderDetailRepository extends JpaRepository<OrderDetail, Long>,OrderDetailRepositoryCustom {
     @Query("SELECT od.book.bookId FROM OrderDetail od WHERE od.orderDetailId = :orderDetailId")
     Optional<Long> findBookIdByOrderDetailId(@Param("orderDetailId") Long orderDetailId);
-
 
 }

--- a/src/main/java/com/nhnacademy/bookstore/orderset/order_detail/repository/OrderDetailRepositoryImpl.java
+++ b/src/main/java/com/nhnacademy/bookstore/orderset/order_detail/repository/OrderDetailRepositoryImpl.java
@@ -5,7 +5,7 @@ import com.nhnacademy.bookstore.orderset.order.entity.QOrder;
 import com.nhnacademy.bookstore.orderset.order_detail.dto.response.OrderDetailResponseDto;
 import com.nhnacademy.bookstore.orderset.order_detail.entity.OrderDetail;
 import com.nhnacademy.bookstore.orderset.order_detail.entity.QOrderDetail;
-import com.nhnacademy.bookstore.user.customer.entity.QCustomer;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -49,6 +49,7 @@ public class OrderDetailRepositoryImpl extends QuerydslRepositorySupport impleme
     public Page<OrderDetailResponseDto> findByCustomerId(Pageable pageable, Long customerId) {
         JPAQuery<OrderDetailResponseDto> query = new JPAQuery<>(getEntityManager());
 
+        // 기본 쿼리 작성
         query.from(qOrderDetail)
                 .join(qOrderDetail.order, qOrder)
                 .join(qOrderDetail.book, qBook)
@@ -62,6 +63,10 @@ public class OrderDetailRepositoryImpl extends QuerydslRepositorySupport impleme
                         qOrderDetail.finalPrice
                 ));
 
+        OrderSpecifier<?> orderSpecifier;
+        orderSpecifier = qOrderDetail.orderDetailId.desc();
+        query.orderBy(orderSpecifier);
+
         // 전체 개수 계산
         long total = query.fetchCount();
 
@@ -73,6 +78,8 @@ public class OrderDetailRepositoryImpl extends QuerydslRepositorySupport impleme
 
         return new PageImpl<>(content, pageable, total);
     }
+
+
 
 }
 


### PR DESCRIPTION
주문상세내역 조회를 내림차순으로 정렬하게 querydsl을 수정했습니다.
수정하는 김에 출판사도 원래는 가나다순 정렬이였지만 id 정렬로 수정했습니다.